### PR TITLE
README.md의 탈자 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## 어떻게 사용하나요?
 
 - python 3.6 이상을 설치하세요.
-- `pip install requirements.txt`
+- `pip install -r requirements.txt`
 - mysql에 데이터베이스를 저장하려면 테이블을 만들어야 합니다.
 ```mysql
 CREATE TABLE `company` (


### PR DESCRIPTION
- `pip install` 명령어에서 `requirements.txt` 파일을 지정하기 위한 `-r` 옵션이 누락되어 있던 것을 추가했습니다.